### PR TITLE
Fix nil error

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 		logplexHandler(rw, req)
 	}
 
-	if aErr != nil {
+	if aErr == nil {
 		http.HandleFunc(nr.WrapHandleFunc(app, "/", mainHandler))
 	} else {
 		http.HandleFunc("/", mainHandler)


### PR DESCRIPTION
Unfortunately we overlooked the conditional logic, which means that `app` is always nil.